### PR TITLE
Fixing problem, if you sit behind a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Breaks the build if the SonarQube quality gate of the project is red.
 
-See [the blog post I wrote](https://qaware.blogspot.com/2020/02/breaking-your-build-on-sonarqube.html) for more details.
+See [the blog post I wrote](https://blog.qaware.de/posts/sonar-qube-build-breaker/) for more details.
 
 ## Components
 

--- a/library/src/main/java/de/qaware/tools/sqbb/library/impl/BuildBreakerFactory.java
+++ b/library/src/main/java/de/qaware/tools/sqbb/library/impl/BuildBreakerFactory.java
@@ -27,7 +27,7 @@ public final class BuildBreakerFactory {
      * @return a BuildBreaker instance
      */
     public static CloseableBuildBreaker create(Duration waitTime, String baseUrl, Authentication authentication) {
-        CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpClient httpClient = HttpClients.createSystem();
         SonarQubeConnector sonarQubeConnector = new SonarQubeConnectorImpl(new ApacheHttpClient(httpClient), baseUrl, authentication);
         BuildBreakerImpl buildBreaker = new BuildBreakerImpl(waitTime, sonarQubeConnector);
 


### PR DESCRIPTION
Hi Moritz,

I fixed a problem of the sonarqube build breaker, if it is used in an environment behind a proxy.

Now, we can configure the Java system property `https.proxyHost` and `https.proxyPort` to configure the proxy server.
In the command line, we provide only `-Dhttps.proxyHost=https://yourProxyUrl` and `https.proxyPort=1234` to be configure the proxy server for the Apache HTTP-Client.

There are much more network properties, which the Apache HTTP-Client is supporting:
```
ssl.TrustManagerFactory.algorithm
javax.net.ssl.trustStoreType
javax.net.ssl.trustStore
javax.net.ssl.trustStoreProvider
javax.net.ssl.trustStorePassword
ssl.KeyManagerFactory.algorithm
javax.net.ssl.keyStoreType
javax.net.ssl.keyStore
javax.net.ssl.keyStoreProvider
javax.net.ssl.keyStorePassword
https.protocols
https.cipherSuites
http.proxyHost
http.proxyPort
https.proxyHost
https.proxyPort
http.nonProxyHosts
http.keepAlive
http.maxConnections
http.agent
```